### PR TITLE
feat: add passport expiry threshold indicator

### DIFF
--- a/src/pages/[passportId].tsx
+++ b/src/pages/[passportId].tsx
@@ -253,10 +253,14 @@ export function VotingPowerChart({ citizen, veNation }: any) {
       {
         name: 'Voting power',
         data: veNation.voting_power_per_week
+      },
+      {
+        name: 'Passport expiry threshold',
+        data: new Array(veNation.voting_power_per_week.length).fill(1.5)
       }
     ],
     options: {
-      colors: ['#88f1bb'],
+      colors: ['#88f1bb', '#e7588f'],
       dataLabels: {
         enabled: false
       },
@@ -264,6 +268,9 @@ export function VotingPowerChart({ citizen, veNation }: any) {
         toolbar: {
           show: false
         }
+      },
+      yaxis: {
+        min: 0
       }
     }
   }


### PR DESCRIPTION
Make it easier for citizens to understand when their `$veNATION` drops below `1.5`.

> ![](https://github.com/nation3/citizen-directory/assets/95955389/3f6f491c-bc07-4d41-81c2-1c4b782a1375)

> ![](https://github.com/nation3/citizen-directory/assets/95955389/bf28ad78-7e58-4ff1-97e7-64c92843edd5)

> ![](https://github.com/nation3/citizen-directory/assets/95955389/7d6c7a22-7d91-408e-8cd6-32f4ca7134d6)

> ![](https://github.com/nation3/citizen-directory/assets/95955389/c519b57d-7358-4542-a99b-5f79730bb9b2)
